### PR TITLE
 🐛 Fix: 커멘트에 맞춰서 수정

### DIFF
--- a/src/main/java/com/hotspot/livfit/badge/controller/BadgeController.java
+++ b/src/main/java/com/hotspot/livfit/badge/controller/BadgeController.java
@@ -1,17 +1,19 @@
 package com.hotspot.livfit.badge.controller;
 
+import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import com.hotspot.livfit.badge.dto.BadgeRequestDTO;
 import com.hotspot.livfit.badge.dto.BadgeResponseDTO;
+import com.hotspot.livfit.badge.entity.UserBadge;
 import com.hotspot.livfit.badge.service.UserBadgeService;
+import com.hotspot.livfit.user.util.JwtUtil;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -24,6 +26,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 public class BadgeController {
 
   private final UserBadgeService userBadgeService;
+  private final JwtUtil jwtUtil;
 
   // 뱃지 조건 확인 및 부여 엔드포인트
   /*
@@ -32,7 +35,7 @@ public class BadgeController {
    * HTTP Body: BadgeRequestDTO 객체 (JSON 형식)
    * 요청 JSON 형식:
    * {
-   *   "userId": 1,
+   *   "userId": 1, // users의 PK 참조
    *   "badgeId": "T",
    *   "conditionCheck": true
    * }
@@ -46,10 +49,25 @@ public class BadgeController {
         @ApiResponse(responseCode = "500", description = "서버 에러")
       })
   @PostMapping("/check-award")
-  public ResponseEntity<?> checkNaward(@RequestBody BadgeRequestDTO badgeRequestDTO) {
+  public ResponseEntity<?> checkandAward( // checkNaward -> checkandAward로 변경
+      @RequestHeader("Authorization") String bearerToken,
+      @RequestBody BadgeRequestDTO badgeRequestDTO) {
+
     try {
+      // 토큰확인 추가
+      // Bearer 토큰에서 JWT 추출
+      String token = bearerToken.substring(7);
+      // JWT에서 사용자 ID 추출
+      String userId = jwtUtil.extractUsername(token);
+
+      // userId와 badgeRequestDTO의 userId가 일치하는지 확인
+      if (!userId.equals(badgeRequestDTO.getUserId().toString())) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+            .body("User ID does not match with the token");
+      }
+
       boolean success =
-          userBadgeService.checkNawardBadge(
+          userBadgeService.checkandAwardBadge( // checkNaward -> checkandAward로 변경
               badgeRequestDTO.getUserId(),
               badgeRequestDTO.getBadgeId(),
               badgeRequestDTO.isConditionCheck());
@@ -60,7 +78,42 @@ public class BadgeController {
         return ResponseEntity.ok(new BadgeResponseDTO(false, "Badge awarded failed"));
       }
     } catch (RuntimeException e) {
-      log.error("Error during badge award in controller /api/register: {}", e.getMessage());
+      log.error(
+          "Error during badge award in controller /api/userbadges/check-award: {}",
+          e.getMessage()); // 유저 컨트롤러 복붙했어서 오타난거 수정..
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  //조회 로직 추가
+  @Operation(summary = "사용자의 모든 뱃지 가져오기", description = "특정 사용자의 모든 뱃지 가져오기")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "뱃지 가져오기 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @ApiResponse(responseCode = "500", description = "서버 에러")
+      })
+  @GetMapping("/{userId}")
+  public ResponseEntity<?> getUserBadges(
+      @RequestHeader("Authorization") String bearerToken, @PathVariable Long userId) {
+    try {
+      // Bearer 토큰에서 JWT 추출
+      String token = bearerToken.substring(7);
+      // JWT에서 사용자 ID 추출
+      String jwtUserId = jwtUtil.extractUsername(token);
+
+      // 요청된 userId와 JWT에서 추출한 userId가 일치하는지 확인
+      if (!jwtUserId.equals(userId.toString())) {
+        return ResponseEntity.badRequest().body("User ID does not match with the token");
+      }
+
+      // userId로 사용자 뱃지 조회
+      List<UserBadge> userBadges = userBadgeService.getUserBadges(userId);
+      return ResponseEntity.ok(userBadges);
+    } catch (RuntimeException e) {
+      log.error(
+          "Error during fetching user badges in controller /api/userbadges/{userId}: {}",
+          e.getMessage());
       return ResponseEntity.badRequest().body(e.getMessage());
     }
   }

--- a/src/main/java/com/hotspot/livfit/badge/controller/BadgeController.java
+++ b/src/main/java/com/hotspot/livfit/badge/controller/BadgeController.java
@@ -1,0 +1,67 @@
+package com.hotspot.livfit.badge.controller;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hotspot.livfit.badge.dto.BadgeRequestDTO;
+import com.hotspot.livfit.badge.dto.BadgeResponseDTO;
+import com.hotspot.livfit.badge.service.UserBadgeService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@RestController
+@RequestMapping("/api/userbadges")
+@RequiredArgsConstructor
+@Slf4j
+public class BadgeController {
+
+  private final UserBadgeService userBadgeService;
+
+  // 뱃지 조건 확인 및 부여 엔드포인트
+  /*
+   * URL: /api/userbadges/check-award
+   * HTTP Method: POST
+   * HTTP Body: BadgeRequestDTO 객체 (JSON 형식)
+   * 요청 JSON 형식:
+   * {
+   *   "userId": 1,
+   *   "badgeId": "T",
+   *   "conditionCheck": true
+   * }
+   */
+
+  @Operation(summary = "뱃지 조건 확인 및 부여", description = "사용자가 특정 뱃지 조건을 만족하면 뱃지를 부여")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "뱃지 부여 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @ApiResponse(responseCode = "500", description = "서버 에러")
+      })
+  @PostMapping("/check-award")
+  public ResponseEntity<?> checkNaward(@RequestBody BadgeRequestDTO badgeRequestDTO) {
+    try {
+      boolean success =
+          userBadgeService.checkNawardBadge(
+              badgeRequestDTO.getUserId(),
+              badgeRequestDTO.getBadgeId(),
+              badgeRequestDTO.isConditionCheck());
+
+      if (success) {
+        return ResponseEntity.ok(new BadgeResponseDTO(true, "Badge awarded successfully"));
+      } else {
+        return ResponseEntity.ok(new BadgeResponseDTO(false, "Badge awarded failed"));
+      }
+    } catch (RuntimeException e) {
+      log.error("Error during badge award in controller /api/register: {}", e.getMessage());
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/hotspot/livfit/badge/dto/BadgeRequestDTO.java
+++ b/src/main/java/com/hotspot/livfit/badge/dto/BadgeRequestDTO.java
@@ -6,7 +6,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class BadgeRequestDTO {
-  private Long userId;
-  private String badgeId;
-  private boolean conditionCheck;
+  private String loginId; // 로그인 아이디
+  private String badgeId; // 뱃지 ID
+  private boolean conditionCheck; // 조건 확인 여부
 }

--- a/src/main/java/com/hotspot/livfit/badge/dto/BadgeRequestDTO.java
+++ b/src/main/java/com/hotspot/livfit/badge/dto/BadgeRequestDTO.java
@@ -1,0 +1,12 @@
+package com.hotspot.livfit.badge.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BadgeRequestDTO {
+  private Long userId;
+  private String badgeId;
+  private boolean conditionCheck;
+}

--- a/src/main/java/com/hotspot/livfit/badge/dto/BadgeResponseDTO.java
+++ b/src/main/java/com/hotspot/livfit/badge/dto/BadgeResponseDTO.java
@@ -1,0 +1,16 @@
+package com.hotspot.livfit.badge.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class BadgeResponseDTO {
+  private boolean success; // 뱃지 부여 성공 여부
+  private String message; // 응답 메시지
+
+  public BadgeResponseDTO(boolean success, String message) {
+    this.success = success;
+    this.message = message;
+  }
+}

--- a/src/main/java/com/hotspot/livfit/badge/entity/Badge.java
+++ b/src/main/java/com/hotspot/livfit/badge/entity/Badge.java
@@ -1,0 +1,26 @@
+package com.hotspot.livfit.badge.entity;
+
+import java.util.UUID;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "badge")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Badge {
+  // 뱃지 id (PK)
+  @Id private String id; // 기본 키는 String 타입
+
+  @PrePersist
+  public void generateId() {
+    if (this.id == null) {
+      this.id = UUID.randomUUID().toString(); // ID를 UUID로 자동 생성
+    }
+  }
+}

--- a/src/main/java/com/hotspot/livfit/badge/entity/UserBadge.java
+++ b/src/main/java/com/hotspot/livfit/badge/entity/UserBadge.java
@@ -1,0 +1,34 @@
+package com.hotspot.livfit.badge.entity;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import jakarta.persistence.*;
+
+import com.hotspot.livfit.user.entity.User;
+
+@Entity
+@Table(name = "user_badge")
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserBadge {
+  // 그냥 PK
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  // 유저 id (PK 참조)
+  @ManyToOne // 한명의 사용자가 여러개의 뱃지를 소유할 수 있으니 다대일
+  @JoinColumn(name = "user_id", referencedColumnName = "id")
+  private User user;
+  // 뱃지 id (PK 참조)
+  @ManyToOne // 여러 사용자?UserBadge?가 하나의 뱃지를 참조할 수 있으니 다대일
+  @JoinColumn(name = "badge_id", referencedColumnName = "id")
+  private Badge badge;
+  // 뱃지 획득 시간
+  @Column(name = "earned_time")
+  private LocalDateTime earnedTime;
+}

--- a/src/main/java/com/hotspot/livfit/badge/entity/UserBadge.java
+++ b/src/main/java/com/hotspot/livfit/badge/entity/UserBadge.java
@@ -20,15 +20,18 @@ public class UserBadge {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  // 유저 id (PK 참조)
+
+  // 유저 id (로그인 아이디 참조)
   @ManyToOne // 한명의 사용자가 여러개의 뱃지를 소유할 수 있으니 다대일
-  @JoinColumn(name = "user_id", referencedColumnName = "id")
+  @JoinColumn(name = "login_id", referencedColumnName = "login_id") // 로그인 아이디 참조로 수정
   private User user;
+
   // 뱃지 id (PK 참조)
   @ManyToOne // 여러 사용자?UserBadge?가 하나의 뱃지를 참조할 수 있으니 다대일
   @JoinColumn(name = "badge_id", referencedColumnName = "id")
   private Badge badge;
+
   // 뱃지 획득 시간
-  @Column(name = "earned_time")
+  @Column(name = "earned_time", nullable = false)
   private LocalDateTime earnedTime;
 }

--- a/src/main/java/com/hotspot/livfit/badge/repository/BadgeRepository.java
+++ b/src/main/java/com/hotspot/livfit/badge/repository/BadgeRepository.java
@@ -1,0 +1,7 @@
+package com.hotspot.livfit.badge.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hotspot.livfit.badge.entity.Badge;
+
+public interface BadgeRepository extends JpaRepository<Badge, String> {}

--- a/src/main/java/com/hotspot/livfit/badge/repository/UserBadgeRepository.java
+++ b/src/main/java/com/hotspot/livfit/badge/repository/UserBadgeRepository.java
@@ -1,0 +1,7 @@
+package com.hotspot.livfit.badge.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hotspot.livfit.badge.entity.UserBadge;
+
+public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {}

--- a/src/main/java/com/hotspot/livfit/badge/repository/UserBadgeRepository.java
+++ b/src/main/java/com/hotspot/livfit/badge/repository/UserBadgeRepository.java
@@ -3,9 +3,14 @@ package com.hotspot.livfit.badge.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
 
 import com.hotspot.livfit.badge.entity.UserBadge;
 
+@Repository
 public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
-  List<UserBadge> findByUserId(Long userId);
+  // 로그인 아이디로 유저뱃지 조회
+  @Query("SELECT ub FROM UserBadge ub WHERE ub.user.loginId = :loginId")
+  List<UserBadge> findByLoginId(String loginId);
 }

--- a/src/main/java/com/hotspot/livfit/badge/repository/UserBadgeRepository.java
+++ b/src/main/java/com/hotspot/livfit/badge/repository/UserBadgeRepository.java
@@ -1,7 +1,11 @@
 package com.hotspot.livfit.badge.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.hotspot.livfit.badge.entity.UserBadge;
 
-public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {}
+public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
+  List<UserBadge> findByUserId(Long userId);
+}

--- a/src/main/java/com/hotspot/livfit/badge/service/UserBadgeService.java
+++ b/src/main/java/com/hotspot/livfit/badge/service/UserBadgeService.java
@@ -1,0 +1,56 @@
+package com.hotspot.livfit.badge.service;
+
+import java.time.LocalDateTime;
+
+import lombok.RequiredArgsConstructor;
+
+import jakarta.transaction.Transactional;
+
+import org.springframework.stereotype.Service;
+
+import com.hotspot.livfit.badge.entity.Badge;
+import com.hotspot.livfit.badge.entity.UserBadge;
+import com.hotspot.livfit.badge.repository.BadgeRepository;
+import com.hotspot.livfit.badge.repository.UserBadgeRepository;
+import com.hotspot.livfit.user.entity.User;
+import com.hotspot.livfit.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor // 생성자 자동 생성, 필요한 필드 주입? 역할
+public class UserBadgeService {
+
+  private final UserRepository UserRepository;
+  private final BadgeRepository BadgeRepository;
+  private final UserBadgeRepository userBadgeRepository;
+  private final UserRepository userRepository;
+  private final BadgeRepository badgeRepository;
+
+  // id로 유저 엔티티 조회
+  @Transactional
+  public boolean checkNawardBadge(Long userId, String badgeId, boolean conditionCheck) {
+    User user =
+        userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found"));
+
+    Badge badge =
+        badgeRepository
+            .findById(badgeId)
+            .orElseThrow(() -> new RuntimeException("Badge not found"));
+
+    if (conditionCheck) {
+      // 조건 만족 시 뱃지 부여
+      awardBadgeToUser(user, badge);
+      return true; // 뱃지 부여
+    } else {
+      return false; // 조건 만족 X
+    }
+  }
+
+  // 유저뱃지 엔티티 생성&저장
+  private void awardBadgeToUser(User user, Badge badge) {
+    UserBadge userBadge = new UserBadge();
+    userBadge.setUser(user);
+    userBadge.setBadge(badge);
+    userBadge.setEarnedTime(LocalDateTime.now());
+    userBadgeRepository.save(userBadge);
+  }
+}

--- a/src/main/java/com/hotspot/livfit/badge/service/UserBadgeService.java
+++ b/src/main/java/com/hotspot/livfit/badge/service/UserBadgeService.java
@@ -24,12 +24,14 @@ public class UserBadgeService {
   private final UserRepository userRepository;
   private final BadgeRepository badgeRepository;
 
-  // id로 유저 엔티티 조회
+  // login id로 유저 엔티티 조회
   @Transactional
   public boolean checkandAwardBadge(
-      Long userId, String badgeId, boolean conditionCheck) { // checkNaward -> checkandAward로 변경
+      String loginId, String badgeId, boolean conditionCheck) { // checkNaward -> checkandAward로 변경
     User user =
-        userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found"));
+        userRepository
+            .findByLoginId(loginId)
+            .orElseThrow(() -> new RuntimeException("User not found"));
 
     Badge badge =
         badgeRepository
@@ -55,7 +57,7 @@ public class UserBadgeService {
   }
 
   // 특정 사용자의 뱃지를 조회
-  public List<UserBadge> getUserBadges(Long userId) {
-    return userBadgeRepository.findByUserId(userId);
+  public List<UserBadge> getUserBadges(String loginId) {
+    return userBadgeRepository.findByLoginId(loginId);
   }
 }

--- a/src/main/java/com/hotspot/livfit/badge/service/UserBadgeService.java
+++ b/src/main/java/com/hotspot/livfit/badge/service/UserBadgeService.java
@@ -1,6 +1,7 @@
 package com.hotspot.livfit.badge.service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import lombok.RequiredArgsConstructor;
 
@@ -19,15 +20,14 @@ import com.hotspot.livfit.user.repository.UserRepository;
 @RequiredArgsConstructor // 생성자 자동 생성, 필요한 필드 주입? 역할
 public class UserBadgeService {
 
-  private final UserRepository UserRepository;
-  private final BadgeRepository BadgeRepository;
   private final UserBadgeRepository userBadgeRepository;
   private final UserRepository userRepository;
   private final BadgeRepository badgeRepository;
 
   // id로 유저 엔티티 조회
   @Transactional
-  public boolean checkNawardBadge(Long userId, String badgeId, boolean conditionCheck) {
+  public boolean checkandAwardBadge(
+      Long userId, String badgeId, boolean conditionCheck) { // checkNaward -> checkandAward로 변경
     User user =
         userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found"));
 
@@ -52,5 +52,10 @@ public class UserBadgeService {
     userBadge.setBadge(badge);
     userBadge.setEarnedTime(LocalDateTime.now());
     userBadgeRepository.save(userBadge);
+  }
+
+  // 특정 사용자의 뱃지를 조회
+  public List<UserBadge> getUserBadges(Long userId) {
+    return userBadgeRepository.findByUserId(userId);
   }
 }

--- a/src/main/java/com/hotspot/livfit/config/SecurityConfig.java
+++ b/src/main/java/com/hotspot/livfit/config/SecurityConfig.java
@@ -47,7 +47,8 @@ public class SecurityConfig {
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/api/users/register",
-                        "/api/users/login")
+                        "/api/users/login",
+                        "/api/userbadges/**")
                     .permitAll()
                     .requestMatchers("/api/v1/user/*")
                     .hasRole("USER")

--- a/src/main/java/com/hotspot/livfit/exercise/entity/TestEntity.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/TestEntity.java
@@ -1,0 +1,3 @@
+package com.hotspot.livfit.exercise.entity;
+
+public class TestEntity {}

--- a/src/main/java/com/hotspot/livfit/exercise/entity/controller/LungeController.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/controller/LungeController.java
@@ -1,0 +1,90 @@
+package com.hotspot.livfit.exercise.entity.controller;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.hotspot.livfit.exercise.entity.dto.Record;
+import com.hotspot.livfit.exercise.entity.entity.Lunge;
+import com.hotspot.livfit.exercise.entity.service.ExerciseService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@RestController
+@RequestMapping("/lunge")
+@RequiredArgsConstructor
+@Slf4j
+public class LungeController {
+  private final ExerciseService exerciseService;
+  // 런지 기록 저장 엔드포인트
+  /*
+   * URL : /api/lunge/record
+   * HTTP Method: POST
+   * 요청 JSON 형식 :
+   * {
+   *   "username" : "test1",
+   *   "token" : "??????",
+   *   "timer_sec" : "60",
+   *   "count" : "15",
+   *   "perfect" : "5",
+   *   "great" : "5",
+   *   "good" : "5"
+   * }
+   * */
+  @Operation(summary = "기록저장", description = "런지 기록 저장")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "기록 완료."),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청."),
+        @ApiResponse(responseCode = "500", description = "서버 에러.")
+      })
+  @PostMapping("/record")
+  public ResponseEntity<?> saveRecord(@RequestBody Record record) {
+    try {
+      Lunge lunge =
+          exerciseService.saveRecordLunge(
+              record.getToken(),
+              record.getUsername(),
+              record.getTimer_sec(),
+              record.getCount(),
+              record.getPerfect(),
+              record.getGreat(),
+              record.getGood());
+      return ResponseEntity.ok(lunge);
+
+    } catch (RuntimeException e) {
+      log.error(
+          "Error during saving Lunge record in controller /api/lunge/record: {}", e.getMessage());
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  // 런지 기록 가져오는 엔드포인트
+  /*
+   * URL : /api/lunge/all
+   * HTTP Method: GET
+   * */
+  @Operation(summary = "기록 가져오기", description = "런지 기록 조회")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = " 가져오기 완료."),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청."),
+        @ApiResponse(responseCode = "500", description = "서버 에러.")
+      })
+  @GetMapping("/all")
+  public ResponseEntity<List<Lunge>> getAllRecords() {
+    try {
+      List<Lunge> lunges = exerciseService.getAllLunge();
+      return ResponseEntity.ok(lunges);
+    } catch (RuntimeException e) {
+      log.error("Error during fetching Lunge records in controller /lunge/all: {}", e.getMessage());
+      return ResponseEntity.status(500).body(null);
+    }
+  }
+}

--- a/src/main/java/com/hotspot/livfit/exercise/entity/controller/PushupController.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/controller/PushupController.java
@@ -1,0 +1,91 @@
+package com.hotspot.livfit.exercise.entity.controller;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.hotspot.livfit.exercise.entity.dto.Record;
+import com.hotspot.livfit.exercise.entity.entity.Pushup;
+import com.hotspot.livfit.exercise.entity.service.ExerciseService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@RestController
+@RequestMapping("/pushup")
+@RequiredArgsConstructor
+@Slf4j
+public class PushupController {
+  private final ExerciseService exerciseService;
+  // 푸쉬업 기록 저장 엔드포인트
+  /*
+   * URL : /api/pushup/record
+   * HTTP Method: POST
+   * 요청 JSON 형식 :
+   * {
+   *   "username" : "test1",
+   *   "token" : "??????",
+   *   "timer_sec" : "60",
+   *   "count" : "15",
+   *   "perfect" : "5",
+   *   "great" : "5",
+   *   "good" : "5"
+   * }
+   * */
+  @Operation(summary = "기록저장", description = "푸쉬업 기록 저장")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "기록 완료."),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청."),
+        @ApiResponse(responseCode = "500", description = "서버 에러.")
+      })
+  @PostMapping("/record")
+  public ResponseEntity<?> saveRecord(@RequestBody Record record) {
+    try {
+      Pushup pushup =
+          exerciseService.saveRecordPushup(
+              record.getToken(),
+              record.getUsername(),
+              record.getTimer_sec(),
+              record.getCount(),
+              record.getPerfect(),
+              record.getGreat(),
+              record.getGood());
+      return ResponseEntity.ok(pushup);
+
+    } catch (RuntimeException e) {
+      log.error(
+          "Error during saving Pushup record in controller /api/pushup/record: {}", e.getMessage());
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  // 푸쉬업 기록 가져오는 엔드포인트
+  /*
+   * URL : /api/pushup/all
+   * HTTP Method: GET
+   * */
+  @Operation(summary = "기록 가져오기", description = "푸쉬업 기록 조회")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = " 가져오기 완료."),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청."),
+        @ApiResponse(responseCode = "500", description = "서버 에러.")
+      })
+  @GetMapping("/all")
+  public ResponseEntity<List<Pushup>> getAllRecords() {
+    try {
+      List<Pushup> pushups = exerciseService.getAllPushup();
+      return ResponseEntity.ok(pushups);
+    } catch (RuntimeException e) {
+      log.error(
+          "Error during fetching pushup records in controller /pushup/all: {}", e.getMessage());
+      return ResponseEntity.status(500).body(null);
+    }
+  }
+}

--- a/src/main/java/com/hotspot/livfit/exercise/entity/controller/SquatController.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/controller/SquatController.java
@@ -1,0 +1,91 @@
+package com.hotspot.livfit.exercise.entity.controller;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.hotspot.livfit.exercise.entity.dto.Record;
+import com.hotspot.livfit.exercise.entity.entity.Squat;
+import com.hotspot.livfit.exercise.entity.service.ExerciseService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@RestController
+@RequestMapping("/squat")
+@RequiredArgsConstructor
+@Slf4j
+public class SquatController {
+  private final ExerciseService exerciseService;
+  // 스쿼트 기록 저장 엔드포인트
+  /*
+   * URL : /api/squat/record
+   * HTTP Method: POST
+   * 요청 JSON 형식 :
+   * {
+   *   "username" : "test1",
+   *   "token" : "??????",
+   *   "timer_sec" : "60",
+   *   "count" : "15",
+   *   "perfect" : "5",
+   *   "great" : "5",
+   *   "good" : "5"
+   * }
+   * */
+  @Operation(summary = "기록저장", description = "푸쉬업 기록 저장")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = "기록 완료."),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청."),
+        @ApiResponse(responseCode = "500", description = "서버 에러.")
+      })
+  @PostMapping("/record")
+  public ResponseEntity<?> saveRecord(@RequestBody Record record) {
+    try {
+      Squat squat =
+          exerciseService.saveRecordSquat(
+              record.getToken(),
+              record.getUsername(),
+              record.getTimer_sec(),
+              record.getCount(),
+              record.getPerfect(),
+              record.getGreat(),
+              record.getGood());
+      return ResponseEntity.ok(squat);
+
+    } catch (RuntimeException e) {
+      log.error(
+          "Error during saving squat record in controller /api/squat/record: {}", e.getMessage());
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  // 스쿼트 기록 가져오는 엔드포인트
+  /*
+   * URL : /api/squat/all
+   * HTTP Method: GET
+   * */
+  @Operation(summary = "기록 가져오기", description = "스쿼트 기록 조회")
+  @ApiResponses(
+      value = {
+        @ApiResponse(responseCode = "200", description = " 가져오기 완료."),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청."),
+        @ApiResponse(responseCode = "500", description = "서버 에러.")
+      })
+  @GetMapping("/all")
+  public ResponseEntity<List<Squat>> getAllRecords() {
+    try {
+      List<Squat> squats = exerciseService.getAllSquat();
+      return ResponseEntity.ok(squats);
+    } catch (RuntimeException e) {
+      log.error(
+          "Error during fetching pushup records in controller /squat/all: {}", e.getMessage());
+      return ResponseEntity.status(500).body(null);
+    }
+  }
+}

--- a/src/main/java/com/hotspot/livfit/exercise/entity/dto/Record.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/dto/Record.java
@@ -1,0 +1,17 @@
+package com.hotspot.livfit.exercise.entity.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+// 기록 데이터를 담고 있는 DTO 클래스
+public class Record {
+  private long timer_sec;
+  private int count;
+  private int perfect;
+  private int great;
+  private int good;
+  private String token;
+  private String username;
+}

--- a/src/main/java/com/hotspot/livfit/exercise/entity/entity/Lunge.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/entity/Lunge.java
@@ -1,0 +1,39 @@
+package com.hotspot.livfit.exercise.entity.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "lunge")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Lunge {
+  // pk 런지 아이디
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  // 시간 초
+  @Column(name = "timer_sec")
+  private long timer_sec;
+
+  // 개수
+  @Column(name = "count")
+  private int count;
+
+  // perfect
+  @Column(name = "perfect")
+  private int perfect;
+
+  // great
+  @Column(name = "great")
+  private int great;
+
+  // good
+  @Column(name = "good")
+  private int good;
+}

--- a/src/main/java/com/hotspot/livfit/exercise/entity/entity/Pushup.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/entity/Pushup.java
@@ -1,0 +1,39 @@
+package com.hotspot.livfit.exercise.entity.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "pushup")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Pushup {
+  // pk 푸쉬업 아이디
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  // 시간 초
+  @Column(name = "timer_sec")
+  private long timer_sec;
+
+  // 개수
+  @Column(name = "count")
+  private int count;
+
+  // perfect
+  @Column(name = "perfect")
+  private int perfect;
+
+  // great
+  @Column(name = "great")
+  private int great;
+
+  // good
+  @Column(name = "good")
+  private int good;
+}

--- a/src/main/java/com/hotspot/livfit/exercise/entity/entity/Squat.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/entity/Squat.java
@@ -1,0 +1,39 @@
+package com.hotspot.livfit.exercise.entity.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "squat")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Squat {
+  // pk 스쿼트 아이디
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  // 시간 초
+  @Column(name = "timer_sec")
+  private long timer_sec;
+
+  // 개수
+  @Column(name = "count")
+  private int count;
+
+  // perfect
+  @Column(name = "perfect")
+  private int perfect;
+
+  // great
+  @Column(name = "great")
+  private int great;
+
+  // good
+  @Column(name = "good")
+  private int good;
+}

--- a/src/main/java/com/hotspot/livfit/exercise/entity/repository/LungeRepository.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/repository/LungeRepository.java
@@ -1,0 +1,7 @@
+package com.hotspot.livfit.exercise.entity.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hotspot.livfit.exercise.entity.entity.Lunge;
+
+public interface LungeRepository extends JpaRepository<Lunge, Long> {}

--- a/src/main/java/com/hotspot/livfit/exercise/entity/repository/PushupRepository.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/repository/PushupRepository.java
@@ -1,0 +1,7 @@
+package com.hotspot.livfit.exercise.entity.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hotspot.livfit.exercise.entity.entity.Pushup;
+
+public interface PushupRepository extends JpaRepository<Pushup, Long> {}

--- a/src/main/java/com/hotspot/livfit/exercise/entity/repository/SquatRepository.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/repository/SquatRepository.java
@@ -1,0 +1,7 @@
+package com.hotspot.livfit.exercise.entity.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hotspot.livfit.exercise.entity.entity.Squat;
+
+public interface SquatRepository extends JpaRepository<Squat, Long> {}

--- a/src/main/java/com/hotspot/livfit/exercise/entity/service/ExerciseService.java
+++ b/src/main/java/com/hotspot/livfit/exercise/entity/service/ExerciseService.java
@@ -1,0 +1,91 @@
+package com.hotspot.livfit.exercise.entity.service;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+
+import com.hotspot.livfit.exercise.entity.entity.Lunge;
+import com.hotspot.livfit.exercise.entity.entity.Pushup;
+import com.hotspot.livfit.exercise.entity.entity.Squat;
+import com.hotspot.livfit.exercise.entity.repository.LungeRepository;
+import com.hotspot.livfit.exercise.entity.repository.PushupRepository;
+import com.hotspot.livfit.exercise.entity.repository.SquatRepository;
+import com.hotspot.livfit.user.util.JwtUtil;
+
+@Service
+@RequiredArgsConstructor
+public class ExerciseService {
+  private final JwtUtil jwtUtil;
+  private final LungeRepository lungeRepository;
+
+  private final PushupRepository pushupRepository;
+  private final SquatRepository squatRepository;
+
+  // 런지 기록 저장 로직
+  public Lunge saveRecordLunge(
+      String token, String username, Long timerSec, int count, int perfect, int good, int great) {
+    // 리프레시 토큰이 있는지 확인
+    if (jwtUtil.validateToken(token, username)) {
+      // 런지 기록 DB에 저장
+      Lunge lunge = new Lunge();
+      lunge.setTimer_sec(timerSec);
+      lunge.setCount(count);
+      lunge.setPerfect(perfect);
+      lunge.setGood(good);
+      lunge.setGreat(great);
+      return lungeRepository.save(lunge);
+    }
+    // 토큰이 없는 경우
+    return null;
+  }
+
+  public List<Lunge> getAllLunge() {
+    return lungeRepository.findAll();
+  }
+
+  // 푸쉬업 기록 저장 로직
+  public Pushup saveRecordPushup(
+      String token, String username, Long timerSec, int count, int perfect, int good, int great) {
+    // 리프레시 토큰이 있는지 확인
+    if (jwtUtil.validateToken(token, username)) {
+      // 푸쉬업 기록 DB에 저장
+      Pushup pushup = new Pushup();
+      pushup.setTimer_sec(timerSec);
+      pushup.setCount(count);
+      pushup.setPerfect(perfect);
+      pushup.setGood(good);
+      pushup.setGreat(great);
+      return pushupRepository.save(pushup);
+    }
+    // 토큰이 없는 경우
+    return null;
+  }
+
+  public List<Pushup> getAllPushup() {
+    return pushupRepository.findAll();
+  }
+
+  // 스쿼트 기록 저장 로직
+  public Squat saveRecordSquat(
+      String token, String username, Long timerSec, int count, int perfect, int good, int great) {
+    // 리프레시 토큰이 있는지 확인
+    if (jwtUtil.validateToken(token, username)) {
+      // 스쿼트 기록 DB에 저장
+      Squat squat = new Squat();
+      squat.setTimer_sec(timerSec);
+      squat.setCount(count);
+      squat.setPerfect(perfect);
+      squat.setGood(good);
+      squat.setGreat(great);
+      return squatRepository.save(squat);
+    }
+    // 토큰이 없는 경우
+    return null;
+  }
+
+  public List<Squat> getAllSquat() {
+    return squatRepository.findAll();
+  }
+}


### PR DESCRIPTION
1. checkNaward -> checkandAward로 변경
2. GET 메서드 로직 추가

API 테스트에 실패해서 어떻게.. 잘 돌아가는지 모르겠숩니다..

로컬에서 테스트를 해보려했는데
로그인을 하고 얻은 accessToken을 Authorization에 Bearer 붙여서 넣고 
{
  "userId": 4,
  "badgeId": "test_badge",
  "conditionCheck": true
}
이런식으로 넣었는데 데베 보고 분명 사용자 ID(User의 PK값 참조) 일치시켰는데
User ID does not match with the token
위와 같이 뜹니다

그런데 여기서 요청형식이 위와 같다면 여기서 유저의 PK값을 알아야만 토큰과 id값을 일치시킬수가 있는건가요??

SecurityConfig -> requestMatchers에서 "/api/userbadges/**" 이거 permitAll해줬는데 
![image](https://github.com/user-attachments/assets/b1c83a0c-ba34-4acf-841e-a3a8b76a6b42)
![image](https://github.com/user-attachments/assets/b6ad85a0-f8ff-40d1-b31f-649a1bcd9496)

요래 뜹니다

뭔가 잘못하고있는 것 같은데.. 뭘 잘못하고있죠??