### PR TITLE
✨ Feat: 포인트 기능 추가 및 SwaggerConfig 수정

### DIFF
--- a/src/main/java/com/hotspot/livfit/config/SecurityConfig.java
+++ b/src/main/java/com/hotspot/livfit/config/SecurityConfig.java
@@ -48,7 +48,14 @@ public class SecurityConfig {
                         "/v3/api-docs/**",
                         "/api/users/register",
                         "/api/users/login",
-                        "/api/userbadges/**")
+                        "/api/userbadges/**",
+                        "/api/lunge/save_record/**",
+                        "/api/lunge/get_my_record/**",
+                        "/api/pushup/save_record/**",
+                        "/api/pushup/get_my_record/**",
+                        "/api/squat/save_record/**",
+                        "/api/squat/get_my_record/**",
+                        "/api/points/**")
                     .permitAll()
                     .requestMatchers("/api/v1/user/*")
                     .hasRole("USER")

--- a/src/main/java/com/hotspot/livfit/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/hotspot/livfit/config/swagger/SwaggerConfig.java
@@ -5,8 +5,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 
 @Configuration
@@ -27,7 +30,21 @@ public class SwaggerConfig {
     return new OpenAPI()
         .addServersItem(localServer)
         .addServersItem(prodServer)
-        .info(new Info().title("livfit API").version("1.0").description("livfit API description"));
+        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+        .components(
+            new Components()
+                .addSecuritySchemes(
+                    "bearerAuth",
+                    new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")))
+        .info(
+            new Info()
+                .title("livfit API")
+                .version("1.0")
+                .description(
+                    "API Test용 ID : test_dev Token : eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJ0ZXN0X2RldiIsImlhdCI6MTcyMjAwOTE5OCwiZXhwIjoxNzIyNjEzOTk4fQ.oxRUEWz4OlOodRVdjGGSy2AQlFwptj_zyYI2VBfwd1o"));
   }
 
   @Bean

--- a/src/main/java/com/hotspot/livfit/point/controller/PointController.java
+++ b/src/main/java/com/hotspot/livfit/point/controller/PointController.java
@@ -1,0 +1,97 @@
+package com.hotspot.livfit.point.controller;
+
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import com.hotspot.livfit.point.dto.PointRequestDTO;
+import com.hotspot.livfit.point.entity.PointHistory;
+import com.hotspot.livfit.point.service.PointService;
+import com.hotspot.livfit.user.util.JwtUtil;
+
+import io.jsonwebtoken.Claims;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+@RestController
+@RequestMapping("/api/points")
+@RequiredArgsConstructor // 필드 주입을 위한 생성자 자동 생성
+@Slf4j
+public class PointController {
+
+  private final PointService pointService;
+  private final JwtUtil jwtUtil;
+
+  @Operation(summary = "포인트 적립/차감", description = "사용자의 포인트를 적립하거나 차감")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "포인트 적립/차감 성공"),
+    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+    @ApiResponse(responseCode = "500", description = "서버 에러")
+  })
+  @PostMapping("/update")
+  public ResponseEntity<?> updatePoints(
+      @RequestHeader("Authorization") String bearerToken,
+      @RequestBody PointRequestDTO pointRequestDTO) {
+    try {
+      String token = bearerToken.substring(7);
+      Claims claims = jwtUtil.getAllClaimsFromToken(token);
+      String loginId = claims.getId(); // 로그인 아이디
+      // 포인트 적립/차감
+      pointService.updatePoints(loginId, pointRequestDTO);
+      return ResponseEntity.ok("Points updated successfully");
+    } catch (RuntimeException e) {
+      log.error(
+          "Error during updating points in controller /api/points/update: {}", e.getMessage());
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  @Operation(summary = "포인트 히스토리 조회", description = "사용자의 포인트 히스토리를 조회")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "포인트 히스토리 조회 성공"),
+    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+    @ApiResponse(responseCode = "500", description = "서버 에러")
+  })
+  @GetMapping
+  public ResponseEntity<?> getPointHistory(@RequestHeader("Authorization") String bearerToken) {
+    try {
+      String token = bearerToken.substring(7);
+      Claims claims = jwtUtil.getAllClaimsFromToken(token);
+      String loginId = claims.getId();
+      // 포인트 히스토리 조회
+      List<PointHistory> history = pointService.getPointHistory(loginId);
+      return ResponseEntity.ok(history);
+    } catch (RuntimeException e) {
+      log.error(
+          "Error during fetching point history in controller /api/points: {}", e.getMessage());
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  @Operation(summary = "누적 포인트 조회", description = "사용자의 누적 포인트를 조회")
+  @ApiResponses({
+    @ApiResponse(responseCode = "200", description = "누적 포인트 조회 성공"),
+    @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+    @ApiResponse(responseCode = "500", description = "서버 에러")
+  })
+  @GetMapping("/total")
+  public ResponseEntity<?> getTotalPoints(@RequestHeader("Authorization") String bearerToken) {
+    try {
+      String token = bearerToken.substring(7);
+      Claims claims = jwtUtil.getAllClaimsFromToken(token);
+      String loginId = claims.getId();
+      // 누적 포인트 조회
+      int totalPoints = pointService.getTotalPoints(loginId);
+      return ResponseEntity.ok(totalPoints);
+    } catch (RuntimeException e) {
+      log.error(
+          "Error during fetching total points in controller /api/points/total: {}", e.getMessage());
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/hotspot/livfit/point/dto/PointRequestDTO.java
+++ b/src/main/java/com/hotspot/livfit/point/dto/PointRequestDTO.java
@@ -1,0 +1,12 @@
+package com.hotspot.livfit.point.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PointRequestDTO {
+  private int points; // 포인트 값
+  private String type; // 포인트 타입 (EARN or SPEND)
+  private String description; // 포인트 적립/차감 이유
+}

--- a/src/main/java/com/hotspot/livfit/point/entity/PointHistory.java
+++ b/src/main/java/com/hotspot/livfit/point/entity/PointHistory.java
@@ -1,0 +1,47 @@
+package com.hotspot.livfit.point.entity;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import jakarta.persistence.*;
+
+import com.hotspot.livfit.user.entity.User;
+
+@Entity
+@Table(name = "point_history")
+@Getter
+@Setter
+@NoArgsConstructor
+public class PointHistory {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  // loginId 참조
+  @ManyToOne
+  @JoinColumn(name = "login_id", referencedColumnName = "login_id")
+  private User user;
+
+  // 이벤트 발생 시간
+  @Column(name = "event_time")
+  private LocalDateTime eventTime;
+
+  // 적립/차감된 포인트 값
+  @Column(name = "points")
+  private int points;
+
+  // 누적 포인트 값
+  @Column(name = "total_points")
+  private int totalPoints;
+
+  // 포인트 적립/차감 타입 (EARN or SPEND)
+  @Column(name = "type")
+  private String type;
+
+  // 포인트 적립/차감에 대한 설명
+  @Column(name = "description")
+  private String description;
+}

--- a/src/main/java/com/hotspot/livfit/point/entity/TestEntity.java
+++ b/src/main/java/com/hotspot/livfit/point/entity/TestEntity.java
@@ -1,3 +1,0 @@
-package com.hotspot.livfit.point.entity;
-
-public class TestEntity {}

--- a/src/main/java/com/hotspot/livfit/point/repository/PointHistoryRepository.java
+++ b/src/main/java/com/hotspot/livfit/point/repository/PointHistoryRepository.java
@@ -1,0 +1,14 @@
+package com.hotspot.livfit.point.repository; // package com.hotspot.livfit.point.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.hotspot.livfit.point.entity.PointHistory;
+
+@Repository
+public interface PointHistoryRepository extends JpaRepository<PointHistory, Long> {
+  // 로그인 아이디로 포인트 기록을 조회
+  List<PointHistory> findByUser_LoginId(String loginId);
+}

--- a/src/main/java/com/hotspot/livfit/point/service/PointService.java
+++ b/src/main/java/com/hotspot/livfit/point/service/PointService.java
@@ -1,0 +1,68 @@
+package com.hotspot.livfit.point.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hotspot.livfit.point.dto.PointRequestDTO;
+import com.hotspot.livfit.point.entity.PointHistory;
+import com.hotspot.livfit.point.repository.PointHistoryRepository;
+import com.hotspot.livfit.user.entity.User;
+import com.hotspot.livfit.user.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PointService {
+  private final PointHistoryRepository pointHistoryRepository;
+  private final UserRepository userRepository;
+
+  @Transactional
+  public void updatePoints(String loginId, PointRequestDTO pointRequestDTO) {
+    User user =
+        userRepository
+            .findByLoginId(loginId)
+            .orElseThrow(() -> new RuntimeException("User not found"));
+
+    // 특정 사용자 ID의 누적 포인트 히스토리 조회
+    List<PointHistory> history = pointHistoryRepository.findByUser_LoginId(loginId);
+
+    // 누적포인트 계산
+    //    int totalPoints = history.isEmpty() ? 0 : history.get(history.size() -
+    // 1).getTotalPoints();
+    int totalPoints = history.stream().mapToInt(PointHistory::getTotalPoints).sum();
+
+    // 포인트 적립 or 차감 계산
+    if (pointRequestDTO.getType().equals("earn")) { // 적립
+      totalPoints += pointRequestDTO.getPoints();
+    } else if (pointRequestDTO.getType().equals("spend")) { // 차감
+      totalPoints -= pointRequestDTO.getPoints();
+    }
+
+    PointHistory pointHistory = new PointHistory();
+    pointHistory.setUser(user);
+    pointHistory.setEventTime(LocalDateTime.now()); // 이벤트 발생 시간
+    pointHistory.setPoints(pointRequestDTO.getPoints()); // 적립하거나 차감된 포인트 값
+    pointHistory.setTotalPoints(totalPoints); // 누적 포인트 값
+    pointHistory.setType(pointRequestDTO.getType()); // 포인트 적립/차감 타입 설정
+    pointHistory.setDescription(pointRequestDTO.getDescription()); // 포인트 적립/차감에 대한 설명
+    pointHistoryRepository.save(pointHistory);
+  }
+
+  // 특정 사용자의 포인트 히스토리 조회
+  public List<PointHistory> getPointHistory(String loginId) {
+    return pointHistoryRepository.findByUser_LoginId(loginId);
+  }
+
+  // 특정 사용자의 누적 포인트 조회
+  public int getTotalPoints(String loginId) {
+    // 특정 사용자 ID의 누적 포인트 히스토리 조회
+    List<PointHistory> history = pointHistoryRepository.findByUser_LoginId(loginId);
+
+    // 누적포인트 계산
+    return history.isEmpty() ? 0 : history.get(history.size() - 1).getTotalPoints();
+  }
+}


### PR DESCRIPTION
1. SwaggerConfig 수정했고,

2. SecurityConfig에서 
"/api/lunge/save_record/**",
                        "/api/lunge/get_my_record/**",
                        "/api/pushup/save_record/**",
                        "/api/pushup/get_my_record/**",
                        "/api/squat/save_record/**",
                        "/api/squat/get_my_record/**",
                        "/api/points/**")
열었습니다 ~

3. 포인트 기능을 추가했습니다.
다만 아직 완료는 못한 것 같은게..
궁금한게 있습니다.

api를 세개 만들었는데요
a. 포인트 적립/차감 POST
b. 사용자의 포인트 히스토리 조회
c. 사용자의 누적포인트 조회

여기서
1. 사용자의 누적포인트 조회 api가 따로 필요한가?
-> 마이페이지에서 사용자의 누적포인트가 보일테니 따로 만들었는데 누적포인트 조회를 그냥 포인트 히스토리의 카테고리 중 누적포인트를 꺼내오면 되는건지 아니면 누적포인트 조회 api가 따로 필요한지 정확히 구분을 못하겠어서 여기서 궁금증이 하나 생겼습니다.

2. 그리고 api 테스트를 진행할 때는 
![image](https://github.com/user-attachments/assets/5251ebcb-06a6-49c4-897b-41285e67a4d7)
위와 같이 보내는데 조건확인을 통해 타입을(spend와 earn) 알아서..? 넣어주는건가요?

그러면 그 조건확인에 대해>>
Badge에서 프론트가 "이 사용자가 조건을 만족했니?" 라는 걸 백에 물으면 그에 대해 yes or no를 알려주는 로직을 짰었는데 여기 포인트 테이블에서 이 조건확인 로직을 추가로 짜야하는지, 
추가로 예를 들어 오늘의 미션을 성공했을 시에도 "이 사용자가 오늘의 미션을 성공했니?" 이 물음을 백에 보낼텐데 이 조건만족 로직을 오늘의 미션에서 짜야하는건지 궁금합니다. 
결론은 : 포인트에서는 조건확인 로직이 필요없는가. 가 궁금합니다

머리가 잘 안 도는건지 구분이 확실하게 안되는것같네융..
아무튼 그래서 여기까지 짰고 dev로 머지 해주시면 될 것 같아요 ~ @april0114 