### PR TITLE
🐛 Fix: challenge 조회 및 여러가지 수정

### DIFF
--- a/src/main/java/com/hotspot/livfit/badge/repository/UserBadgeRepository.java
+++ b/src/main/java/com/hotspot/livfit/badge/repository/UserBadgeRepository.java
@@ -27,4 +27,8 @@ public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
   // 사용자가 소유한 뱃지 개수 조회 (마이페이지에서 뱃지 개수를 나타내기 위한 쿼리)
   @Query("SELECT COUNT(ub) FROM UserBadge ub WHERE ub.user.loginId = :loginId")
   int countByLoginId(String loginId);
+
+  // 메인 뱃지 조회
+  @Query("SELECT ub FROM UserBadge ub WHERE ub.user.loginId = :loginId AND ub.mainBadge = true")
+  Optional<UserBadge> findMainBadgeByLoginId(String loginId);
 }

--- a/src/main/java/com/hotspot/livfit/badge/service/UserBadgeService.java
+++ b/src/main/java/com/hotspot/livfit/badge/service/UserBadgeService.java
@@ -31,23 +31,23 @@ public class UserBadgeService {
   public boolean checkandAwardBadge(String loginId, String badgeId, boolean conditionCheck) {
     // loginId를 사용하여 사용자 조회
     User user =
-            userRepository
-                    .findByLoginId(loginId)
-                    .orElseThrow(
-                            () -> {
-                              log.error("User not found with login ID: {}", loginId);
-                              return new RuntimeException("User not found");
-                            });
+        userRepository
+            .findByLoginId(loginId)
+            .orElseThrow(
+                () -> {
+                  log.error("User not found with login ID: {}", loginId);
+                  return new RuntimeException("User not found");
+                });
 
     // badgeId를 사용하여 Badge 조회
     Badge badge =
-            badgeRepository
-                    .findById(badgeId)
-                    .orElseThrow(
-                            () -> {
-                              log.error("Badge not found with badge ID: {}", badgeId);
-                              return new RuntimeException("Badge not found");
-                            });
+        badgeRepository
+            .findById(badgeId)
+            .orElseThrow(
+                () -> {
+                  log.error("Badge not found with badge ID: {}", badgeId);
+                  return new RuntimeException("Badge not found");
+                });
 
     if (conditionCheck) {
       // 사용자가 해당 뱃지를 이미 가지고 있는지 확인
@@ -62,9 +62,9 @@ public class UserBadgeService {
       }
     } else {
       log.warn(
-              "Condition check failed for awarding badge '{}' to user with login ID '{}'",
-              badgeId,
-              loginId);
+          "Condition check failed for awarding badge '{}' to user with login ID '{}'",
+          badgeId,
+          loginId);
     }
     return false; // 조건을 만족하지 않거나 이미 뱃지를 소유하고 있는 경우
   }
@@ -72,9 +72,9 @@ public class UserBadgeService {
   // 유저뱃지 엔티티 생성&저장
   private void awardBadgeToUser(User user, Badge badge) {
     log.info(
-            "Creating UserBadge entity for user with ID '{}' and badge '{}'",
-            user.getId(),
-            badge.getId());
+        "Creating UserBadge entity for user with ID '{}' and badge '{}'",
+        user.getId(),
+        badge.getId());
     UserBadge userBadge = new UserBadge();
     userBadge.setUser(user);
     userBadge.setBadge(badge);
@@ -82,7 +82,7 @@ public class UserBadgeService {
     userBadgeRepository.save(userBadge);
 
     log.info(
-            "UserBadge entity saved for user with ID '{}' and badge '{}'", user.getId(), badge.getId());
+        "UserBadge entity saved for user with ID '{}' and badge '{}'", user.getId(), badge.getId());
   }
 
   // 메인 뱃지 설정 메서드
@@ -90,13 +90,13 @@ public class UserBadgeService {
   public void setMainBadge(String loginId, String badgeId) {
     // 로그인 ID로 사용자 조회
     User user =
-            userRepository
-                    .findByLoginId(loginId)
-                    .orElseThrow(
-                            () -> {
-                              log.error("User not found with login ID: {}", loginId);
-                              return new RuntimeException("User not found");
-                            });
+        userRepository
+            .findByLoginId(loginId)
+            .orElseThrow(
+                () -> {
+                  log.error("User not found with login ID: {}", loginId);
+                  return new RuntimeException("User not found");
+                });
 
     // 이전 메인 뱃지를 모두 해제
     List<UserBadge> userBadges = userBadgeRepository.findByLoginId(loginId);
@@ -107,16 +107,16 @@ public class UserBadgeService {
 
     // 새로운 메인 뱃지 설정
     UserBadge mainBadge =
-            userBadgeRepository
-                    .findByUser_LoginIdAndBadge_Id(loginId, badgeId)
-                    .orElseThrow(
-                            () -> {
-                              log.error(
-                                      "UserBadge not found for user with login ID '{}' and badge ID '{}'",
-                                      loginId,
-                                      badgeId);
-                              return new RuntimeException("UserBadge not found");
-                            });
+        userBadgeRepository
+            .findByUser_LoginIdAndBadge_Id(loginId, badgeId)
+            .orElseThrow(
+                () -> {
+                  log.error(
+                      "UserBadge not found for user with login ID '{}' and badge ID '{}'",
+                      loginId,
+                      badgeId);
+                  return new RuntimeException("UserBadge not found");
+                });
 
     mainBadge.setMainBadge(true);
     userBadgeRepository.save(mainBadge);

--- a/src/main/java/com/hotspot/livfit/challenge/dto/ChallengeDTO.java
+++ b/src/main/java/com/hotspot/livfit/challenge/dto/ChallengeDTO.java
@@ -8,7 +8,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class ChallengeDTO {
-  private String loginId;
   private LocalDateTime startedAt;
   private String success;
   private String Title;

--- a/src/main/java/com/hotspot/livfit/challenge/dto/UserChallengeDTO.java
+++ b/src/main/java/com/hotspot/livfit/challenge/dto/UserChallengeDTO.java
@@ -1,0 +1,21 @@
+package com.hotspot.livfit.challenge.dto;
+
+import java.time.LocalDateTime;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+// 응답 dto
+@Getter
+@Setter
+@AllArgsConstructor
+public class UserChallengeDTO {
+  private Long id;
+  private String loginId;
+  private String nickname;
+  private String title;
+  private String content;
+  private LocalDateTime startedAt;
+  private String success;
+}

--- a/src/main/java/com/hotspot/livfit/challenge/entity/ChallengeUserEntity.java
+++ b/src/main/java/com/hotspot/livfit/challenge/entity/ChallengeUserEntity.java
@@ -24,19 +24,20 @@ public class ChallengeUserEntity {
 
   // 개인 여러개 챌린지 기록을 가지고 있으므로
   @ManyToOne
-  @JoinColumn(name = "user_id", referencedColumnName = "id")
+  @JoinColumn(name = "user_id", referencedColumnName = "login_id")
   private User user;
 
   // 챌린지 내용 제목 가져오기
   @ManyToOne(fetch = FetchType.EAGER)
   @JoinColumn(name = "challenge_id", referencedColumnName = "id")
   private ChallengeEntity challenge;
+
   // 챌린지 시작한 날짜
   @Column(name = "started_at")
   private LocalDateTime startedAt;
 
-  @Column(name = "loginid")
-  private String loginId;
+  //  @Column(name = "loginid")
+  //  private String loginId;
 
   // 성공 실패 여부
   @Column(name = "success")

--- a/src/main/java/com/hotspot/livfit/config/SecurityConfig.java
+++ b/src/main/java/com/hotspot/livfit/config/SecurityConfig.java
@@ -56,7 +56,8 @@ public class SecurityConfig {
                         "/api/challenge/**",
                         "/api/mypage/**",
                         "/api/today_exercise/**",
-                        "/api/turtle/**")
+                        "/api/turtle/**",
+                        "/api/mainpage/**")
                     .permitAll()
                     .requestMatchers("/api/v1/user/*")
                     .hasRole("USER")

--- a/src/main/java/com/hotspot/livfit/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/hotspot/livfit/config/swagger/SwaggerConfig.java
@@ -44,7 +44,7 @@ public class SwaggerConfig {
                 .title("livfit API")
                 .version("1.0")
                 .description(
-                    "API Test용 ID : test_dev Token : eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJ0ZXN0X2RldiIsImlhdCI6MTcyMjAwOTE5OCwiZXhwIjoxNzIyNjEzOTk4fQ.oxRUEWz4OlOodRVdjGGSy2AQlFwptj_zyYI2VBfwd1o"));
+                    "API Test용 ID : test_dev Token : eyJhbGciOiJIUzI1NiJ9.eyJqdGkiOiJ0ZXN0X2RldiIsImlhdCI6MTcyMjQwNzkzOSwiZXhwIjoxNzIzMDEyNzM5fQ.sFqi7VT-MMSYnmsjKmAGl1zviZMSZhunMwUYFZQYF4g"));
   }
 
   @Bean

--- a/src/main/java/com/hotspot/livfit/mypage/controller/MyPageController.java
+++ b/src/main/java/com/hotspot/livfit/mypage/controller/MyPageController.java
@@ -6,6 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import com.hotspot.livfit.badge.dto.MainBadgeRequestDTO;
+import com.hotspot.livfit.badge.service.UserBadgeService;
 import com.hotspot.livfit.mypage.dto.MyPageResponseDTO;
 import com.hotspot.livfit.mypage.dto.NicknameUpdateRequestDTO;
 import com.hotspot.livfit.mypage.service.MyPageService;
@@ -21,6 +23,7 @@ import io.swagger.v3.oas.annotations.Operation;
 public class MyPageController {
 
   private final MyPageService myPageService;
+  private final UserBadgeService userBadgeService;
   private final JwtUtil jwtUtil;
 
   // 마이페이지 정보 조회
@@ -60,6 +63,28 @@ public class MyPageController {
     } catch (RuntimeException e) {
       log.error(
           "Error during updating nickname in controller /api/mypage/nickname: {}", e.getMessage());
+      return ResponseEntity.badRequest().body(e.getMessage());
+    }
+  }
+
+  @Operation(summary = "메인 뱃지 설정", description = "사용자가 메인 뱃지를 설정")
+  @PostMapping("/set-main-badge")
+  public ResponseEntity<?> setMainBadge(
+      @RequestHeader("Authorization") String bearerToken,
+      @RequestBody MainBadgeRequestDTO mainBadgeRequestDTO) {
+
+    try {
+      String token = bearerToken.substring(7);
+      Claims claims = jwtUtil.getAllClaimsFromToken(token);
+      String jwtLoginId = claims.getId();
+
+      userBadgeService.setMainBadge(jwtLoginId, mainBadgeRequestDTO.getBadgeId());
+      log.info("{} 사용자의 메인뱃지를 {}로 설정 성공.", jwtLoginId, mainBadgeRequestDTO.getBadgeId());
+      return ResponseEntity.ok("Main badge set successfully from MyPage");
+    } catch (RuntimeException e) {
+      log.error(
+          "Error during setting main badge in MyPage controller /api/mypage/set-main-badge: {}",
+          e.getMessage());
       return ResponseEntity.badRequest().body(e.getMessage());
     }
   }

--- a/src/main/java/com/hotspot/livfit/mypage/dto/MyPageResponseDTO.java
+++ b/src/main/java/com/hotspot/livfit/mypage/dto/MyPageResponseDTO.java
@@ -6,7 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
 
-import com.hotspot.livfit.challenge.entity.ChallengeEntity;
+import com.hotspot.livfit.challenge.dto.UserChallengeDTO;
 
 @Getter
 @Setter
@@ -15,6 +15,7 @@ public class MyPageResponseDTO {
   private String loginId;
   private String nickname;
   private int totalPoints;
+  private String mainBadgeId; // 메인 뱃지 ID
   private int badgeCount; // 사용자가 소유한 뱃지 개수 추가
-  private List<ChallengeEntity> challengeEntities;
+  private List<UserChallengeDTO> UserChallenges; // 사용자의 챌린지 기록
 }

--- a/src/main/java/com/hotspot/livfit/mypage/service/MyPageService.java
+++ b/src/main/java/com/hotspot/livfit/mypage/service/MyPageService.java
@@ -34,9 +34,9 @@ public class MyPageService {
   @Transactional(readOnly = true)
   public MyPageResponseDTO getMyPageInfo(String loginId) {
     User user =
-            userRepository
-                    .findByLoginId(loginId)
-                    .orElseThrow(() -> new RuntimeException("User not found"));
+        userRepository
+            .findByLoginId(loginId)
+            .orElseThrow(() -> new RuntimeException("User not found"));
 
     // 특정 사용자 ID의 누적 포인트 히스토리 조회하고
     int totalPoints = 0;
@@ -53,7 +53,7 @@ public class MyPageService {
     int badgeCount = userBadgeRepository.countByLoginId(loginId);
 
     return new MyPageResponseDTO(
-            user.getLoginId(), user.getNickname(), totalPoints, badgeCount, challengeEntities);
+        user.getLoginId(), user.getNickname(), totalPoints, badgeCount, challengeEntities);
   }
 
   // LungeEntity를 LungeDTO로 변환
@@ -102,9 +102,9 @@ public class MyPageService {
   @Transactional
   public void updateNickname(String loginId, String newNickname) {
     User user =
-            userRepository
-                    .findByLoginId(loginId)
-                    .orElseThrow(() -> new RuntimeException("User not found"));
+        userRepository
+            .findByLoginId(loginId)
+            .orElseThrow(() -> new RuntimeException("User not found"));
     user.setNickname(newNickname);
     userRepository.save(user);
   }

--- a/src/main/java/com/hotspot/livfit/mypage/service/MyPageService.java
+++ b/src/main/java/com/hotspot/livfit/mypage/service/MyPageService.java
@@ -1,21 +1,19 @@
 package com.hotspot.livfit.mypage.service;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.hotspot.livfit.badge.entity.UserBadge;
 import com.hotspot.livfit.badge.repository.UserBadgeRepository;
-import com.hotspot.livfit.challenge.entity.ChallengeEntity;
-import com.hotspot.livfit.challenge.repository.ChallengeRepository;
-import com.hotspot.livfit.exercise.dto.LungeDTO;
-import com.hotspot.livfit.exercise.dto.PushupDTO;
-import com.hotspot.livfit.exercise.dto.SquatDTO;
-import com.hotspot.livfit.exercise.entity.LungeEntity;
-import com.hotspot.livfit.exercise.entity.PushupEntity;
-import com.hotspot.livfit.exercise.entity.SquatEntity;
+import com.hotspot.livfit.challenge.dto.UserChallengeDTO;
+import com.hotspot.livfit.challenge.entity.ChallengeUserEntity;
+import com.hotspot.livfit.challenge.repository.ChallengeUserRepository;
 import com.hotspot.livfit.mypage.dto.MyPageResponseDTO;
 import com.hotspot.livfit.point.entity.PointHistory;
 import com.hotspot.livfit.point.repository.PointHistoryRepository;
@@ -28,7 +26,7 @@ public class MyPageService {
 
   private final UserRepository userRepository;
   private final PointHistoryRepository pointHistoryRepository;
-  private final ChallengeRepository challengeRepository;
+  private final ChallengeUserRepository challengeUserRepository;
   private final UserBadgeRepository userBadgeRepository;
 
   @Transactional(readOnly = true)
@@ -46,56 +44,38 @@ public class MyPageService {
       totalPoints = history.get(history.size() - 1).getTotalPoints();
     }
 
-    // 모든 챌린지 조회
-    List<ChallengeEntity> challengeEntities = challengeRepository.findAllChallenges();
-
     // 뱃지 개수 조회 추가
     int badgeCount = userBadgeRepository.countByLoginId(loginId);
 
+    // 메인 뱃지 조회
+    Optional<UserBadge> mainBadgeOpt = userBadgeRepository.findMainBadgeByLoginId(loginId);
+    String mainBadgeId =
+        mainBadgeOpt.map(UserBadge::getBadge).map(badge -> badge.getId()).orElse(null);
+
+    // 사용자의 모든 챌린지 기록 조회
+    List<UserChallengeDTO> challengeUserDTOs =
+        challengeUserRepository.findByLoginId(loginId).stream()
+            .map(this::convertToUserChallengeDTO)
+            .collect(Collectors.toList());
+
     return new MyPageResponseDTO(
-        user.getLoginId(), user.getNickname(), totalPoints, badgeCount, challengeEntities);
+        user.getLoginId(),
+        user.getNickname(),
+        totalPoints,
+        mainBadgeId,
+        badgeCount,
+        challengeUserDTOs);
   }
 
-  // LungeEntity를 LungeDTO로 변환
-  private LungeDTO convertToLungeDTO(LungeEntity lungeEntity) {
-    LungeDTO dto = new LungeDTO();
-    dto.setLogin_id(lungeEntity.getUser().getLoginId());
-    dto.setTimer_sec(lungeEntity.getTimer_sec());
-    dto.setCount(lungeEntity.getCount());
-    dto.setPerfect(lungeEntity.getPerfect());
-    dto.setGreat(lungeEntity.getGreat());
-    dto.setGood(lungeEntity.getGood());
-    dto.setCreated_at(lungeEntity.getCreated_at());
-    dto.setGraph(lungeEntity.getGraph());
-    return dto;
-  }
-
-  // PushupEntity를 PushupDTO로 변환
-  private PushupDTO convertToPushupDTO(PushupEntity pushupEntity) {
-    PushupDTO dto = new PushupDTO();
-    dto.setLogin_id(pushupEntity.getUser().getLoginId());
-    dto.setTimer_sec(pushupEntity.getTimer_sec());
-    dto.setCount(pushupEntity.getCount());
-    dto.setPerfect(pushupEntity.getPerfect());
-    dto.setGreat(pushupEntity.getGreat());
-    dto.setGood(pushupEntity.getGood());
-    dto.setCreated_at(pushupEntity.getCreated_at());
-    dto.setGraph(pushupEntity.getGraph());
-    return dto;
-  }
-
-  // SquatEntity를 SquatDTO로 변환
-  private SquatDTO convertToSquatDTO(SquatEntity squatEntity) {
-    SquatDTO dto = new SquatDTO();
-    dto.setLogin_id(squatEntity.getUser().getLoginId());
-    dto.setTimer_sec(squatEntity.getTimer_sec());
-    dto.setCount(squatEntity.getCount());
-    dto.setPerfect(squatEntity.getPerfect());
-    dto.setGreat(squatEntity.getGreat());
-    dto.setGood(squatEntity.getGood());
-    dto.setCreated_at(squatEntity.getCreated_at());
-    dto.setGraph(squatEntity.getGraph());
-    return dto;
+  private UserChallengeDTO convertToUserChallengeDTO(ChallengeUserEntity entity) {
+    return new UserChallengeDTO(
+        entity.getId(),
+        entity.getUser().getLoginId(),
+        entity.getUser().getNickname(),
+        entity.getChallenge().getTitle(),
+        entity.getChallenge().getContent(),
+        entity.getStartedAt(),
+        entity.getSuccess());
   }
 
   // 닉네임 업데이트

--- a/src/main/java/com/hotspot/livfit/point/service/PointService.java
+++ b/src/main/java/com/hotspot/livfit/point/service/PointService.java
@@ -5,8 +5,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
-
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/com/hotspot/livfit/today_exercise/dto/TodayExerciseDTO.java
+++ b/src/main/java/com/hotspot/livfit/today_exercise/dto/TodayExerciseDTO.java
@@ -8,7 +8,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class TodayExerciseDTO {
-  private String loginId;
   private DayOfWeek dayOfWeek;
   private String success;
 }


### PR DESCRIPTION
1. 챌린지 엔티티보니까 count column 등 컬럼을 삭제했는데도 여전히 데베에 컬럼이 남아있어서 create으로 다시 데배 생성함.
-> 그래서 데베 초기화됐고, 현재 데이터 몇개씩만 다시 채워놓음

2. test_dev 재가입에 따라 스웨거컨피그에 test_dev 토큰 수정함

3. SecurityConfig에 "/api/mainpage/**" 추가

4. 오늘의 운동 및 챌린지에서 요청에 loginId 둘다 삭제함.
![image](https://github.com/user-attachments/assets/a0add579-e953-4f1f-8849-0146b5085013)

5. 
![image](https://github.com/user-attachments/assets/1328d6a4-76a4-44d9-ae83-1a62c4b93631)
챌린지 요청에 success에 저거 쓰는건가요.??

===========================================================
### 챌린지 변경사항 많아서 적어놓을게요


1. 변경 전에 챌린지엔티티가 조회되는 것이 아니라 그냥 조회가 안되었음
2. 엔티티를 보니 로그인 아이디를 조회하도록 서비스&컨트롤러를 설정해놓았는데 엔티티에서는 유저의 pk를 참조
![image](https://github.com/user-attachments/assets/b089354a-3c80-475a-a42f-76958da8596c)
![image](https://github.com/user-attachments/assets/5bc79413-f212-4515-98ce-d0a9cd645318)
![image](https://github.com/user-attachments/assets/990677d8-2ab2-4c9d-91d5-76d8c236e7bc)

그래서 저 String형인 login_id라는 컬럼 삭제하고 로그인 아이디를 참조해오도록 수정.

3. 그리고 여기서 ChallengeDTO는 요청DTO
![image](https://github.com/user-attachments/assets/1b2fb919-6745-4886-91d6-75157495c9cd)
위 사진을 보면 챌린지유저 엔티티가 아닌 요청 dto->챌린지 엔티티 이렇게 되어있었음

4. 
![image](https://github.com/user-attachments/assets/250b6903-f37d-4547-a6cf-d8cf88109a52)
그래서 요것도 수정했음

5. 응답 DTO 생성해서 id, 로그인 아이디, 닉네임, 타이틀, 컨텐츠, 시작시간, success 가 응답에 뜨도록 설정

7. 추가로 내가 알아보기위해 챌린지에 스웨거 @Operation 추가함

8. 챌린지 api 모두 api 테스트 완료